### PR TITLE
Customize stylesheet entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ When you're developing your application, you want to run Dart Sass in watch mode
 
 The `dartsass:build` is automatically attached to `assets:precompile`, so before the asset pipeline digests the files, the Dart Sass output will be generated.
 
+## Configuring Stylesheets
+
+By default, only `app/assets/stylesheets/application.scss` will be built. If you'd like to change the path of this stylesheet, add additional entry points, or customize the name of the built file, use the `Rails.application.config.dartsass.stylesheets` configuration hash.
+
+
+```
+# config/initializers/dartsass.rb
+Rails.application.config.dartsass.stylesheets = {
+  'app/index.sass'  => 'app.css',
+  'site.scss'       => 'site.css'
+}
+```
+
+The has key is the relative path to a Sass file in `app/assets/stylesheets/` and the hash value will be the name of the file output to `app/assets/builds/`.
+
 
 ## Version
 

--- a/lib/dartsass/engine.rb
+++ b/lib/dartsass/engine.rb
@@ -2,5 +2,7 @@ require "rails"
 
 module Dartsass
   class Engine < ::Rails::Engine
+    config.dartsass = ActiveSupport::OrderedOptions.new
+    config.dartsass.stylesheets = { 'application.scss' => 'appliction.css' }
   end
 end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,14 +1,17 @@
-DARTSASS_COMPILE_COMMAND = "#{Pathname.new(__dir__).to_s}/../../exe/dartsass #{Rails.root.join("app/assets/stylesheets/application.scss")} #{Rails.root.join("app/assets/builds/application.scss")}"
+def dartsass_compile_command
+  stylesheet_map = Rails.application.config.dartsass.stylesheets.map{|k, v| "#{Rails.root.join('app/assets/stylesheets', k)}:#{Rails.root.join('app/assets/builds', v)}"}.join(' ')
+  "#{Pathname.new(__dir__).to_s}/../../exe/dartsass #{stylesheet_map}"
+end
 
 namespace :dartsass do
   desc "Build your Dart Sass CSS"
-  task :build do
-    system DARTSASS_COMPILE_COMMAND
+  task build: :environment do
+    system dartsass_compile_command
   end
 
   desc "Watch and build your Dart Sass CSS on file changes"
-  task :watch do
-    system "#{DARTSASS_COMPILE_COMMAND} -w"
+  task watch: :environment do
+    system "#{dartsass_compile_command} -w"
   end
 end
 


### PR DESCRIPTION
In order to support additional stylesheets or non-standard naming, this change will expose the build path via a configuration hash. I've started with a pattern of:

`config.dartsass.stylesheets = { 'application.scss' => 'appliction.css' }`

In actual code, this ends up looking like this in our application:

```
# config/initializers/dartsass.rb
Rails.application.config.dartsass.stylesheets = {
  'app/index.sass'   => 'app.css',
  'embed/index.sass' => 'embed.css',
  'site/index.sass'  => 'site.css'
}
```

I'm open to a different convention. I could see using more implicit magic (extracting the output naming from the input file (or directory, in the case of `index.sass/scss`). But I don't have a sense of where this is aiming (perhaps some coupling with propshaft?), so this felt like the simplest option.