### PR TITLE
Add an option to add extra load paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Rails.application.config.dartsass.builds = {
 
 The hash key is the relative path to a Sass file in `app/assets/stylesheets/` and the hash value will be the name of the file output to `app/assets/builds/`.
 
+By default, only files under `app/assets/stylesheets` will be watched. If you'd like to add extra directories, use the `Rails.application.config.dartsass.extra_load_paths` configuration array.
+
+```
+# config/initializers/dartsass.rb
+Rails.application.config.dartsass.extra_load_paths = ["app/components"]
+```
 
 ## Version
 

--- a/lib/dartsass/engine.rb
+++ b/lib/dartsass/engine.rb
@@ -4,5 +4,6 @@ module Dartsass
   class Engine < ::Rails::Engine
     config.dartsass = ActiveSupport::OrderedOptions.new
     config.dartsass.builds = { "application.scss" => "application.css" }
+    config.dartsass.extra_load_paths = []
   end
 end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,13 +3,19 @@ CSS_LOAD_PATH  = Rails.root.join("app/assets/stylesheets")
 CSS_BUILD_PATH = Rails.root.join("app/assets/builds")
 
 def dartsass_build_mapping
-  Rails.application.config.dartsass.builds.map { |input, output| 
+  Rails.application.config.dartsass.builds.map { |input, output|
     "#{CSS_LOAD_PATH.join(input)}:#{CSS_BUILD_PATH.join(output)}"
   }.join(" ")
 end
 
 def dartsass_build_options
-  "--load-path #{CSS_LOAD_PATH} --style=compressed --no-source-map"
+  "#{load_paths} --style=compressed --no-source-map"
+end
+
+def load_paths
+  [CSS_LOAD_PATH].concat(Rails.application.config.dartsass.extra_load_paths)
+                 .map { |path| "--load-path #{path}" }
+                 .join(" ")
 end
 
 def dartsass_compile_command


### PR DESCRIPTION
This change allows to add extra [load paths](https://sass-lang.com/documentation/cli/dart-sass#load-path) to the sass executable.

It is helpful when the an app has cutomized the entry points as well as when the entry points references other files that reside outside of the default `CSS_LOAD_PATH`.

That way, when files are changed under those extra directories, `dartsass:watch` will trigger a rebuild.