### PR TITLE
Add app asset paths to load paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Rails.application.config.dartsass.builds = {
 
 The hash key is the relative path to a Sass file in `app/assets/stylesheets/` and the hash value will be the name of the file output to `app/assets/builds/`.
 
+## Importing assets from gems
+`dartsass:build` includes application [assets paths](https://guides.rubyonrails.org/asset_pipeline.html#search-paths) as Sass [load paths](https://sass-lang.com/documentation/at-rules/use#load-paths). Assuming the gem has made assets visible to the Rails application, no additional configuration is required to use them.
+
 
 ## Version
 

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,13 +3,19 @@ CSS_LOAD_PATH  = Rails.root.join("app/assets/stylesheets")
 CSS_BUILD_PATH = Rails.root.join("app/assets/builds")
 
 def dartsass_build_mapping
-  Rails.application.config.dartsass.builds.map { |input, output| 
+  Rails.application.config.dartsass.builds.map { |input, output|
     "#{CSS_LOAD_PATH.join(input)}:#{CSS_BUILD_PATH.join(output)}"
   }.join(" ")
 end
 
 def dartsass_build_options
-  "--load-path #{CSS_LOAD_PATH} --style=compressed --no-source-map"
+  "#{load_paths} --style=compressed --no-source-map"
+end
+
+def load_paths
+  [CSS_LOAD_PATH].concat(Rails.application.config.assets.paths)
+                 .map { |path| "--load-path #{path}" }
+                 .join(" ")
 end
 
 def dartsass_compile_command

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -9,17 +9,15 @@ def dartsass_build_mapping
 end
 
 def dartsass_build_options
-  "#{load_paths} --style=compressed --no-source-map"
+  "--style=compressed --no-source-map"
 end
 
-def load_paths
-  [CSS_LOAD_PATH].concat(Rails.application.config.assets.paths)
-                 .map { |path| "--load-path #{path}" }
-                 .join(" ")
+def dartsass_load_paths
+  [ CSS_LOAD_PATH ].concat(Rails.application.config.assets.paths).map { |path| "--load-path #{path}" }.join(" ")
 end
 
 def dartsass_compile_command
-   "#{EXEC_PATH} #{dartsass_build_options} #{dartsass_build_mapping}"
+   "#{EXEC_PATH} #{dartsass_build_options} #{dartsass_load_paths} #{dartsass_build_mapping}"
 end
 
 namespace :dartsass do


### PR DESCRIPTION
Use asset pipeline [asset paths](https://guides.rubyonrails.org/asset_pipeline.html#search-paths) as additional load paths.
Gem assets will also be included when they follow the [convention](https://guides.rubyonrails.org/asset_pipeline.html#adding-assets-to-your-gems).

This approach will also work for custom setups regarding engines, as long as they also make assets available as described in the [guide](https://guides.rubyonrails.org/engines.html#assets). 

A demo working with bootstrap can be seen [here](https://github.com/chipairon/dartsass-demo/commit/efc35fc92e2f71992d28f431344127974570b0b6).

This should superseed https://github.com/rails/dartsass-rails/pull/7 defaulting on Rails asset paths.

