### PR TITLE
Fix platform detection for JRuby

### DIFF
--- a/exe/dartsass
+++ b/exe/dartsass
@@ -2,17 +2,18 @@
 # because rubygems shims assume a gem's executables are Ruby
 
 require "shellwords"
+require "rbconfig"
 
-platform_info = Gem::Platform.local
-platform_string = "#{platform_info.cpu}-#{platform_info.os}"
+system_config = RbConfig::CONFIG
+platform_string = "#{system_config["host_cpu"]}-#{system_config["host_os"]}"
 
-exe_path = 
+exe_path =
   case platform_string
-  when "aarch64-linux" then File.join(__dir__, "aarch64-linux/sass")
-  when "arm64-darwin" then File.join(__dir__, "arm64-darwin/sass")
-  when /darwin\z/  then File.join(__dir__, "darwin/sass")
-  when /linux\z/   then File.join(__dir__, "linux/sass")
-  when /mingw32\z/ then File.join(__dir__, "mingw32/sass.bat")
+  when /aarch64-linux/ then File.join(__dir__, "aarch64-linux/sass")
+  when /arm64-darwin/ then File.join(__dir__, "arm64-darwin/sass")
+  when /darwin/ then File.join(__dir__, "darwin/sass")
+  when /linux/ then File.join(__dir__, "linux/sass")
+  when /mswin|mingw|cygwin/ then File.join(__dir__, "mingw32/sass.bat")
   else
     STDERR.puts(<<~ERRMSG)
       ERROR: dartsass-rails does not support the #{platform_string} platform


### PR DESCRIPTION
After this change dartsass seems to work fine in JRuby and fixes the issue reported in

https://github.com/rails/dartsass-rails/issues/8