### PR TITLE
Use Kernel.exec instead of system

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -23,12 +23,12 @@ end
 namespace :dartsass do
   desc "Build your Dart Sass CSS"
   task build: :environment do
-    system dartsass_compile_command
+    Kernel.exec(dartsass_compile_command)
   end
 
   desc "Watch and build your Dart Sass CSS on file changes"
   task watch: :environment do
-    system "#{dartsass_compile_command} -w"
+    Kernel.exec("#{dartsass_compile_command} -w")
   end
 end
 


### PR DESCRIPTION
Currently, when ending the watch process, something like this is printed:
```
^Crails aborted!
Interrupt: 
/Users/fabian/code/rails/app/bin/rails:5:in `<top (required)>'
/Users/fabian/code/rails/app/bin/spring:10:in `block in <top (required)>'
/Users/fabian/code/rails/app/bin/spring:7:in `<top (required)>'
Tasks: TOP => dartsass:watch
(See full trace by running task with --trace)
```

When using `Kernel.exec` the rake process is replaced with the dartsass process, so the signal goes directly to dartsass, properly ending the process.

I adopted this from webpacker, see https://github.com/rails/webpacker/blob/14dcce2c23a207062e0fc4ebed6042381dabd66a/lib/webpacker/dev_server_runner.rb#L87-L89