### PR TITLE
Allow customizing dartsass executable(Allow using JS version of Dartsass)

### DIFF
--- a/exe/dartsass
+++ b/exe/dartsass
@@ -15,17 +15,17 @@ if (exe_option = ARGV.find { |a| a.match?(/--exe/) })
   system(command)
 else
   exe_path = case platform_string
-  when /aarch64-linux/ then File.join(__dir__, "aarch64-linux/sass")
-  when /arm64-darwin/ then File.join(__dir__, "arm64-darwin/sass")
-  when /darwin/ then File.join(__dir__, "darwin/sass")
-  when /linux/ then File.join(__dir__, "linux/sass")
-  when /mswin|mingw|cygwin/ then File.join(__dir__, "mingw32/sass.bat")
-  else
-    STDERR.puts(<<~ERRMSG)
-      ERROR: dartsass-rails does not support the #{platform_string} platform
-    ERRMSG
-    exit 1
-  end
+             when /aarch64-linux/ then File.join(__dir__, "aarch64-linux/sass")
+             when /arm64-darwin/ then File.join(__dir__, "arm64-darwin/sass")
+             when /darwin/ then File.join(__dir__, "darwin/sass")
+             when /linux/ then File.join(__dir__, "linux/sass")
+             when /mswin|mingw|cygwin/ then File.join(__dir__, "mingw32/sass.bat")
+             else
+               STDERR.puts(<<~ERRMSG)
+                 ERROR: dartsass-rails does not support the #{platform_string} platform
+               ERRMSG
+               exit 1
+             end
 
   command = Shellwords.join([ exe_path, ARGV ].flatten)
   puts "+ #{command}"

--- a/exe/dartsass
+++ b/exe/dartsass
@@ -7,8 +7,14 @@ require "rbconfig"
 system_config = RbConfig::CONFIG
 platform_string = "#{system_config["host_cpu"]}-#{system_config["host_os"]}"
 
-exe_path =
-  case platform_string
+if (exe_option = ARGV.find { |a| a.match?(/--exe/) })
+  exe_path = exe_option.match(/(?<executable>--exe=)(?<command>.*)/)[:command]
+  ARGV.delete(exe_option)
+  command = Shellwords.join([exe_path.split(' '), ARGV ].flatten)
+  puts "+ #{command}"
+  system(command)
+else
+  exe_path = case platform_string
   when /aarch64-linux/ then File.join(__dir__, "aarch64-linux/sass")
   when /arm64-darwin/ then File.join(__dir__, "arm64-darwin/sass")
   when /darwin/ then File.join(__dir__, "darwin/sass")
@@ -21,6 +27,7 @@ exe_path =
     exit 1
   end
 
-command = Shellwords.join([ exe_path, ARGV ].flatten)
-puts "+ #{command}"
-exec(command)
+  command = Shellwords.join([ exe_path, ARGV ].flatten)
+  puts "+ #{command}"
+  exec(command)
+end


### PR DESCRIPTION
I've had similar problem as I guess https://github.com/rails/dartsass-rails/pull/14 tried to solve - my server were running on *BSD system and we were . But digging through `Dart-Sass` repository issues I've found out that there is no `dartsass` executable available for BSD systems.

The way to go in such case seems to be using the Javascript version of `dartsass`.

This change is checking if there is `--exe` option passed, if so then it's executing it as system command. I've used it by adding:
```ruby
# config/initializers/dartsass.rb

Rails.application.config.dartsass.build_options << " --exe=\"yarn run build:css:production\""
```
having the `build:css:production` task in `package.json`:
```
"scripts": {
    "build:css": "sass ./app/assets/stylesheets/application.sass.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules",
    "build:css:production": "sass"
  }
```

Probably not ideal solution but using Javascript library should work on all platforms so could be used as a fallback.