### PR TITLE
Don't print expanded sass command

### DIFF
--- a/exe/dartsass
+++ b/exe/dartsass
@@ -22,5 +22,4 @@ exe_path =
   end
 
 command = Shellwords.join([ exe_path, ARGV ].flatten)
-puts "+ #{command}"
 exec(command)


### PR DESCRIPTION
Hi and thanks for a great project!

I find the printing of the full expanded sass command when running `bin/rails test:system` or `bin/rails test:all` a bit distracting. Would you accept a patch either completely removing it (like this one), or allowing it to be silenced with a config option?