### PR TITLE
Fix detecting of Apple Silicon architecture

### DIFF
--- a/exe/dartsass
+++ b/exe/dartsass
@@ -10,7 +10,7 @@ platform_string = "#{system_config["host_cpu"]}-#{system_config["host_os"]}"
 exe_path =
   case platform_string
   when /aarch64-linux/ then File.join(__dir__, "aarch64-linux/sass")
-  when /arm64-darwin/ then File.join(__dir__, "arm64-darwin/sass")
+  when /arm(64)?-darwin/ then File.join(__dir__, "arm64-darwin/sass")
   when /darwin/ then File.join(__dir__, "darwin/sass")
   when /linux/ then File.join(__dir__, "linux/sass")
   when /mswin|mingw|cygwin/ then File.join(__dir__, "mingw32/sass.bat")


### PR DESCRIPTION
On some Macs, Ruby reports the host CPU as "arm". Might be related to which version of the kernel is installed, but uname still reports "arm64".

This is an extract of `RbConfig::CONFIG`:

```ruby
{
  "target_os"=>"darwin21",
  "target_vendor"=>"apple",
  "target_cpu"=>"arm64",
  "target"=>"arm64-apple-darwin21",
  "host_os"=>"darwin21.3.0",
  "host_vendor"=>"apple",
  "host_cpu"=>"arm",
  "host"=>"arm-apple-darwin21.3.0",
  "RUBY_VERSION_NAME"=>"ruby-2.7.0",
  "RUBYW_BASE_NAME"=>"rubyw",
  "RUBY_BASE_NAME"=>"ruby",
  "build_os"=>"darwin21.3.0",
  "build_vendor"=>"apple",
  "build_cpu"=>"arm",
  "build"=>"arm-apple-darwin21.3.0",
}
```