### PR TITLE
Shell safe file paths

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -4,7 +4,7 @@ CSS_BUILD_PATH = Rails.root.join("app/assets/builds")
 
 def dartsass_build_mapping
   Rails.application.config.dartsass.builds.map { |input, output|
-    "#{CSS_LOAD_PATH.join(input)}:#{CSS_BUILD_PATH.join(output)}"
+    "#{Shellwords.escape(CSS_LOAD_PATH.join(input))}:#{Shellwords.escape(CSS_BUILD_PATH.join(output))}"
   }.join(" ")
 end
 

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -13,7 +13,7 @@ def dartsass_build_options
 end
 
 def dartsass_load_paths
-  [ CSS_LOAD_PATH ].concat(Rails.application.config.assets.paths).map { |path| "--load-path #{path}" }.join(" ")
+  [ CSS_LOAD_PATH ].concat(Rails.application.config.assets.paths).map { |path| "--load-path #{Shellwords.escape(path)}" }.join(" ")
 end
 
 def dartsass_compile_command


### PR DESCRIPTION
Use `Shellwords.escape` to handle spaces in file paths when composing the shell script paths used to invoke the Sass rake tasks, like `bundle exec rails dartsass:build` and `bundle exec rails dartsass:watch`.

Without this, a space in the file path, like `/Users/me/Company Name/rails-app`, results in the error `Positional and ":" arguments may not both be used` during `build`.   The offending spaces are then in the `/app/assets/` (etc) folder paths that are loaded and also in the `CSS_LOAD_PATH` and `CSS_BUILD_PATH`.