### PR TITLE
Add a configurable exec_path for dart sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ By default, sass is invoked with `--style=compressed --no-source-map`. You can a
 Rails.application.config.dartsass.build_options << " --quiet-deps"
 ```
 
+## Configuring exec path
+
+By default, the sass command is determined by the `exe/dartsass` script. You can change the exec path for sass by
+overwriting `Rails.application.config.dartsass.exec_path`.
+
 ## Importing assets from gems
 `dartsass:build` includes application [assets paths](https://guides.rubyonrails.org/asset_pipeline.html#search-paths) as Sass [load paths](https://sass-lang.com/documentation/at-rules/use#load-paths). Assuming the gem has made assets visible to the Rails application, no additional configuration is required to use them.
 

--- a/lib/dartsass/engine.rb
+++ b/lib/dartsass/engine.rb
@@ -5,5 +5,6 @@ module Dartsass
     config.dartsass = ActiveSupport::OrderedOptions.new
     config.dartsass.builds = { "application.scss" => "application.css" }
     config.dartsass.build_options = "--style=compressed --no-source-map"
+    config.dartsass.exec_path = "#{Pathname.new(__dir__).to_s}/../../exe/dartsass"
   end
 end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,4 +1,3 @@
-EXEC_PATH      = "#{Pathname.new(__dir__).to_s}/../../exe/dartsass"
 CSS_LOAD_PATH  = Rails.root.join("app/assets/stylesheets")
 CSS_BUILD_PATH = Rails.root.join("app/assets/builds")
 
@@ -16,8 +15,12 @@ def dartsass_load_paths
   [ CSS_LOAD_PATH ].concat(Rails.application.config.assets.paths).map { |path| "--load-path #{Shellwords.escape(path)}" }.join(" ")
 end
 
+def dartsass_exec_path
+  Rails.application.config.dartsass.exec_path
+end
+
 def dartsass_compile_command
-   "#{EXEC_PATH} #{dartsass_build_options} #{dartsass_load_paths} #{dartsass_build_mapping}"
+  "#{dartsass_exec_path} #{dartsass_build_options} #{dartsass_load_paths} #{dartsass_build_mapping}"
 end
 
 namespace :dartsass do


### PR DESCRIPTION
Our rails monolith has a split where it still uses sprockets for some assets, and webpacker for others. With our upgrade of webpacker we are now using dart sass for webpack assets. This PR allows the configuration of the exec path so that both our sprockets asset pipeline and webpack asset pipeline use the same version of dart sass.