### PR TITLE
Use array args instead of string args for system command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
         gemfile:
           - Gemfile
           - gemfiles/rails_7_0_propshaft.gemfile
@@ -17,6 +18,11 @@ jobs:
           - gemfiles/rails_7_0_sprockets.gemfile
           - gemfiles/rails_7_1_sprockets.gemfile
           - gemfiles/rails_main_sprockets.gemfile
+        exclude:
+          - ruby-version: "3.0"
+            gemfile: gemfiles/rails_main_propshaft.gemfile
+          - ruby-version: "3.0"
+            gemfile: gemfiles/rails_main_sprockets.gemfile
         continue-on-error: [ false ]
 
     name: ${{ format('Tests (Ruby {0}, {1})', matrix.ruby-version, matrix.gemfile) }}

--- a/README.md
+++ b/README.md
@@ -35,13 +35,22 @@ Rails.application.config.dartsass.builds = {
 
 The hash key is the relative path to a Sass file in `app/assets/stylesheets/` and the hash value will be the name of the file output to `app/assets/builds/`.
 
-## Configuring build options
-
-By default, sass is invoked with `--style=compressed --no-source-map`. You can adjust these options by overwriting `Rails.application.config.dartsass.build_options`.
+If both the hash key and the hash value are directories instead of files, it configures a directory to directory compliation, which compiles all public Sass files whose filenames do not start with underscore (`_`).
 
 ```ruby
 # config/initializers/dartsass.rb
-Rails.application.config.dartsass.build_options << " --quiet-deps"
+Rails.application.config.dartsass.builds = {
+  "." => "."
+}
+```
+
+## Configuring build options
+
+By default, sass is invoked with `["--style=compressed", "--no-source-map"]`. You can adjust these options by overwriting `Rails.application.config.dartsass.build_options`.
+
+```ruby
+# config/initializers/dartsass.rb
+Rails.application.config.dartsass.build_options << "--no-charset" << "--quiet-deps"
 ```
 
 ## Importing assets from gems

--- a/dartsass-rails.gemspec
+++ b/dartsass-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true"
   }
 
-  spec.files = Dir["{lib,exe}/**/*", "MIT-LICENSE", "LICENSE-DEPENDENCIES", "Rakefile", "README.md"]
+  spec.files = Dir["{lib,exe}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   spec.bindir = "exe"
   spec.executables << "dartsass"
 

--- a/lib/dartsass/engine.rb
+++ b/lib/dartsass/engine.rb
@@ -4,6 +4,6 @@ module Dartsass
   class Engine < ::Rails::Engine
     config.dartsass = ActiveSupport::OrderedOptions.new
     config.dartsass.builds = { "application.scss" => "application.css" }
-    config.dartsass.build_options = "--style=compressed --no-source-map"
+    config.dartsass.build_options = ["--style=compressed", "--no-source-map"]
   end
 end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -9,7 +9,7 @@ def dartsass_build_mapping
 end
 
 def dartsass_build_options
-  Rails.application.config.dartsass.build_options.map(&:strip)
+  Rails.application.config.dartsass.build_options.flat_map(&:split)
 end
 
 def dartsass_load_paths

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -4,31 +4,31 @@ CSS_BUILD_PATH = Rails.root.join("app/assets/builds")
 
 def dartsass_build_mapping
   Rails.application.config.dartsass.builds.map { |input, output|
-    "#{Shellwords.escape(CSS_LOAD_PATH.join(input))}:#{Shellwords.escape(CSS_BUILD_PATH.join(output))}"
-  }.join(" ")
+    "#{CSS_LOAD_PATH.join(input)}:#{CSS_BUILD_PATH.join(output)}"
+  }
 end
 
 def dartsass_build_options
-  Rails.application.config.dartsass.build_options
+  Rails.application.config.dartsass.build_options.map(&:strip)
 end
 
 def dartsass_load_paths
-  [ CSS_LOAD_PATH ].concat(Rails.application.config.assets.paths).map { |path| "--load-path #{Shellwords.escape(path)}" }.join(" ")
+  [ CSS_LOAD_PATH ].concat(Rails.application.config.assets.paths).flat_map { |path| ["--load-path", path.to_s] }
 end
 
 def dartsass_compile_command
-   "#{EXEC_PATH} #{dartsass_build_options} #{dartsass_load_paths} #{dartsass_build_mapping}"
+  [ RbConfig.ruby, EXEC_PATH ].concat(dartsass_build_options).concat(dartsass_load_paths).concat(dartsass_build_mapping)
 end
 
 namespace :dartsass do
   desc "Build your Dart Sass CSS"
   task build: :environment do
-    system dartsass_compile_command, exception: true
+    system(*dartsass_compile_command, exception: true)
   end
 
   desc "Watch and build your Dart Sass CSS on file changes"
   task watch: :environment do
-    system "#{dartsass_compile_command} -w", exception: true
+    system(*dartsass_compile_command, "--watch", exception: true)
   end
 end
 

--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -1,6 +1,6 @@
 namespace :dartsass do
   desc "Install Dart Sass into the app"
   task :install do
-    system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/dartsass.rb", __dir__)}", exception: true
+    system RbConfig.ruby, "./bin/rails", "app:template", "LOCATION=#{File.expand_path("../install/dartsass.rb", __dir__)}", exception: true
   end
 end


### PR DESCRIPTION
This PR has the following changes:

1. Replace the string command with array command to avoid spawning a subshell before execute the child process. This also remove the need of escaping command and arguments, because the array form is treated literally.
2. Add ruby interpreter to run ruby script, so that it works on windows where shebang is not supported.

- Closes #41