### PR TITLE
Perform recursive file search when clobbering

### DIFF
--- a/lib/tasks/clobber.rake
+++ b/lib/tasks/clobber.rake
@@ -1,8 +1,8 @@
 namespace :dartsass do
   desc "Remove CSS builds"
   task :clobber do
-    rm_rf Dir["app/assets/builds/[^.]*.css"], verbose: false
-    rm_rf Dir["app/assets/builds/[^.]*.css\.map"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.css"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.css\.map"], verbose: false
   end
 end
 


### PR DESCRIPTION
Ensures all css and css.map files are removed, not just the ones at the root of the `/builds` directory.