### PR TITLE
Skip dartsass:build if environment variable `SKIP_CSS_BUILD` is set.

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -32,10 +32,12 @@ namespace :dartsass do
   end
 end
 
-Rake::Task["assets:precompile"].enhance(["dartsass:build"])
+unless ENV["SKIP_CSS_BUILD"]
+  Rake::Task["assets:precompile"].enhance(["dartsass:build"])
 
-if Rake::Task.task_defined?("test:prepare")
-  Rake::Task["test:prepare"].enhance(["dartsass:build"])
-elsif Rake::Task.task_defined?("db:test:prepare")
-  Rake::Task["db:test:prepare"].enhance(["dartsass:build"])
+  if Rake::Task.task_defined?("test:prepare")
+    Rake::Task["test:prepare"].enhance(["dartsass:build"])
+  elsif Rake::Task.task_defined?("db:test:prepare")
+    Rake::Task["db:test:prepare"].enhance(["dartsass:build"])
+  end
 end


### PR DESCRIPTION
Hello,

dartsass-rails gem currently runs `dartsass:build` automatically during `assets:precompile`.
This behavior is enforced by the code here:
https://github.com/rails/dartsass-rails/blob/d227ae6f3c4fe3a962ebd57efb03b21f4d301017/lib/tasks/build.rake#L35

However, in some scenarios, it's beneficial to run `dartsass:build` and `assets:precompile` separately.

For example, the cssbundling-rails gem offers a way to skip its build process during `assets:precompile` by setting an environment variable `SKIP_CSS_BUILD`, as introduced by https://github.com/rails/cssbundling-rails/pull/99.

To align dartsass-rails with this approach, I suggest a similar feature.