### PR TITLE
README: Fix typo (missing space) on Rails.application.config.dartsass.build_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ By default, sass is invoked with `["--style=compressed", "--no-source-map"]`. Yo
 
 ```ruby
 # config/initializers/dartsass.rb
-Rails.application.config.dartsass.build_options << "--no-charset" << "--quiet-deps"
+Rails.application.config.dartsass.build_options << " --no-charset" << " --quiet-deps"
 ```
 
 ## Importing assets from gems


### PR DESCRIPTION
In the README.md:
`Rails.application.config.dartsass.build_options << "--no-charset" << "--quiet-deps"`

Produces with a fresh app:
```bash
02:56:29 css.1  | Could not find an option named "no-source-map--no-charset--quiet-deps".
02:56:29 css.1  |
02:56:29 css.1  | Usage: sass <input.scss> [output.css]
02:56:29 css.1  |        sass <input.scss>:<output.css> <input/>:<output/> <dir/>
```

By default Rails.application.config.dartsass.build_options is:
`--style=compressed --no-source-map`

We have to add space before the first of each dashes.
`Rails.application.config.dartsass.build_options << " --no-charset" << " --quiet-deps"`