### PR TITLE
Force bin/dev overwrite to deal with new default bin/dev file

### DIFF
--- a/lib/install/dartsass.rb
+++ b/lib/install/dartsass.rb
@@ -32,7 +32,7 @@ else
 end
 
 say "Add bin/dev to start foreman"
-copy_file "#{__dir__}/dev", "bin/dev"
+copy_file "#{__dir__}/dev", "bin/dev", force: true
 chmod "bin/dev", 0755, verbose: false
 
 say "Compile initial Dart Sass build"


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/52433.

Fixes `rails new myapp --main --css sass` currently blocking, waiting for user input:

```
  Add bin/dev to start foreman
    conflict    bin/dev
  Overwrite /Users/jerome/c/rails/myapp/bin/dev? (enter "h" for help) [Ynaqdhm]
```

After merging this PR, it would be nice if a new release could be cut, so `rails new myapp --main --css sass` doesn't block.