### PR TITLE
Disable loading .env file when running foreman for development

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -5,4 +5,4 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
-exec foreman start -f Procfile.dev "$@"
+exec foreman start -f Procfile.dev --env /dev/null "$@"


### PR DESCRIPTION
Same as in rails/cssbundling-rails#155 and rails/jsbundling-rails@0ff85a2255b732556ee30d28634ecdb15a50d0ae

We should just not load the .env when running foreman locally for bundling etc.