### PR TITLE
Update root Gemfile bundler version to resolve multiple warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,4 +189,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.32
+   2.5.23


### PR DESCRIPTION
The previous Bundler version used was emitting these warnings. This now installs a current version of Bundler after running `bundle update --bundler` as noted in the lock file.

```
/Users/j.julio/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.2.32/lib/bundler/vendor/thor/lib/thor/error.rb:105: warning: constant DidYouMean::SPELL_CHECKERS is deprecated
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
/Users/j.julio/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.2.32/lib/bundler/rubygems_ext.rb:116: warning: method redefined; discarding old encode_with
/Users/j.julio/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/rubygems/dependency.rb:341: warning: previous definition of encode_with was here
/Users/j.julio/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.2.32/lib/bundler/vendor/thor/lib/thor/error.rb:105: warning: constant DidYouMean::SPELL_CHECKERS is deprecated
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```